### PR TITLE
feat：float32_pub.cppの追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,17 +12,11 @@ find_package(std_msgs REQUIRED)
 
 # talker
 add_executable(talker src/publisher_member_function.cpp)
-ament_target_dependencies(talker 
-  rclcpp 
-  std_msgs
-)
+ament_target_dependencies(talker rclcpp std_msgs)
 
 # listener
 add_executable(listener src/subscriber_member_function.cpp)
-ament_target_dependencies(listener 
-  rclcpp 
-  std_msgs
-)
+ament_target_dependencies(listener rclcpp std_msgs)
 
 # float32_pub
 add_executable(float32_pub src/float32_pub.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,16 +10,31 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 
+# talker
 add_executable(talker src/publisher_member_function.cpp)
-ament_target_dependencies(talker rclcpp std_msgs)
+ament_target_dependencies(talker 
+  rclcpp 
+  std_msgs
+)
 
+# listener
 add_executable(listener src/subscriber_member_function.cpp)
-ament_target_dependencies(listener rclcpp std_msgs)
+ament_target_dependencies(listener 
+  rclcpp 
+  std_msgs
+)
+
+# float32_pub
+add_executable(float32_pub src/float32_pub.cpp)
+ament_target_dependencies(float32_pub rclcpp std_msgs)
+
+#target_link_libraries(float32_pub)
 
 # Install Cpp executables
 install(TARGETS
   talker
   listener
+  float32_pub
   DESTINATION lib/${PROJECT_NAME})
 
 # Install other files

--- a/launch/tutorial_publishers.py
+++ b/launch/tutorial_publishers.py
@@ -17,9 +17,16 @@ def generate_launch_description():
         output="screen",
     )
 
+    float32_node = Node(
+        package=package_name,
+        executable='float32_pub',
+        output="screen",
+    )
+    
     nodes = [
         minimal_publisher_node,
         minimal_subscriber_node,
+        float32_node,
     ]
 
     return LaunchDescription(nodes)

--- a/launch/tutorial_publishers.py
+++ b/launch/tutorial_publishers.py
@@ -22,7 +22,7 @@ def generate_launch_description():
         executable='float32_pub',
         output="screen",
     )
-    
+
     nodes = [
         minimal_publisher_node,
         minimal_subscriber_node,

--- a/src/float32_pub.cpp
+++ b/src/float32_pub.cpp
@@ -13,10 +13,8 @@ public:
   : Node("float32_pub")
   {
     publisher_ = create_publisher<std_msgs::msg::Float32>("/data", 10);
-    timer_ =
-      create_wall_timer(
-      std::chrono::seconds(1),
-      std::bind(&Float32PubComponent::publishData, this));
+    timer_ = create_wall_timer(
+      std::chrono::seconds(1), std::bind(&Float32PubComponent::publishData, this));
   }
 
 private:

--- a/src/float32_pub.cpp
+++ b/src/float32_pub.cpp
@@ -1,0 +1,51 @@
+// 必要なヘッダーファイルをインクルード
+#include <chrono>      // 時間に関する標準ライブラリ
+#include <functional>  // 関数オブジェクトに関する機能を提供
+#include <memory>      // スマートポインタなどのメモリ管理機能を提供
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/float32.hpp"
+
+class Float32PubComponent : public rclcpp::Node
+{
+public:
+  Float32PubComponent()
+  : Node("float32_pub")
+  {
+    publisher_ = create_publisher<std_msgs::msg::Float32>("/data", 10);
+    timer_ =
+      create_wall_timer(
+      std::chrono::seconds(1),
+      std::bind(&Float32PubComponent::publishData, this));
+  }
+
+private:
+  void publishData()
+  {
+    std_msgs::msg::Float32 msg;
+    msg.data = count_;
+
+    RCLCPP_INFO(get_logger(), "Publishing: %f", msg.data);
+
+    publisher_->publish(msg);
+    count_++;
+
+    if (count_ > count_limit_) {
+      count_ = 0.0;
+    }
+  }
+
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  float count_ = 0;
+  float count_limit_ = 40;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  //auto node = std::make_shared<Float32PubComponent>();
+  rclcpp::spin(std::make_shared<Float32PubComponent>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
概要
- 

std_msgs/msg/float32の使用例

変更点
- 
- srcにfloat32_pub.cppを追加
- float32_pubに関わるCMakeLists.txt修正
- float32_pubに関わるtutorial_publishers.pyを修正

確認内容
- 
- [x] colcon build
- [x] colcon test
- [x] /dataトピックの出力確認