### PR TITLE
feat：add laserscan_pub & update rviz2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 # talker
 add_executable(talker src/publisher_member_function.cpp)
@@ -31,12 +32,17 @@ ament_target_dependencies(float32_pub rclcpp std_msgs)
 add_executable(odometry_pub src/odometry_pub.cpp)
 ament_target_dependencies(odometry_pub rclcpp tf2_geometry_msgs nav_msgs geometry_msgs tf2_ros)
 
+# laserscan_pub
+add_executable(laserscan_pub src/laserscan_pub.cpp)
+ament_target_dependencies(laserscan_pub rclcpp sensor_msgs tf2_ros geometry_msgs)
+
 # Install Cpp executables
 install(TARGETS
   talker
   listener
   float32_pub
   odometry_pub
+  laserscan_pub
   DESTINATION lib/${PROJECT_NAME})
 
 # Install other files

--- a/launch/tutorial_publishers.py
+++ b/launch/tutorial_publishers.py
@@ -45,12 +45,19 @@ def generate_launch_description():
         output="screen",
     )
 
+    laserscan_node = Node(
+        package=package_name,
+        executable='laserscan_pub',
+        output="screen",
+    )
+
     nodes = [
         rviz_node,
         minimal_publisher_node,
         minimal_subscriber_node,
         float32_node,
         odometry_node,
+        laserscan_node,
     ]
 
     return LaunchDescription(nodes)

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <depend>nav_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>sensor_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rviz/arcanain_tutorial.rviz
+++ b/rviz/arcanain_tutorial.rviz
@@ -7,7 +7,7 @@ Panels:
         - /Global Options1
         - /Status1
       Splitter Ratio: 0.5
-    Tree Height: 582
+    Tree Height: 746
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -25,7 +25,7 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: ""
+    SyncSource: LaserScan
 Visualization Manager:
   Class: ""
   Displays:
@@ -33,7 +33,7 @@ Visualization Manager:
       Cell Size: 1
       Class: rviz_default_plugins/Grid
       Color: 160; 160; 164
-      Enabled: true 
+      Enabled: true
       Line Style:
         Line Width: 0.029999999329447746
         Value: Lines
@@ -45,6 +45,101 @@ Visualization Manager:
         Z: 0
       Plane: XY
       Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/LaserScan
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 100
+      Min Color: 0; 0; 0
+      Min Intensity: 100
+      Name: LaserScan
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.10000000149011612
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /scan
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz_default_plugins/Path
+      Color: 25; 255; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /odom_path
+      Value: true
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        base_link:
+          Value: true
+        laser_frame:
+          Value: true
+        map:
+          Value: true
+        odom:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        map:
+          odom:
+            base_link:
+              laser_frame:
+                {}
+      Update Interval: 0
+      Value: true
+    - Class: rviz_default_plugins/Axes
+      Enabled: true
+      Length: 1
+      Name: Axes
+      Radius: 0.10000000149011612
       Reference Frame: <Fixed Frame>
       Value: true
   Enabled: true
@@ -93,33 +188,33 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 10
+      Distance: 14.139177322387695
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 0
-        Y: 0
-        Z: 0
+        X: 2.035867691040039
+        Y: 0.23078519105911255
+        Z: 1.6241111755371094
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.785398006439209
+      Pitch: 1.3847965002059937
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 0.785398006439209
+      Yaw: 3.1454081535339355
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 879
+  Height: 1043
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd000000040000000000000156000002d1fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002d1000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002d1fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d000002d1000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b0000002fb00fffffffb0000000800540069006d006501000000000000045000000000000000000000023f000002d100000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000015600000375fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000375000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000375fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d00000375000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d0065010000000000000780000002fb00fffffffb0000000800540069006d006501000000000000045000000000000000000000050f0000037500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -128,6 +223,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 1200
-  X: 70
-  Y: 27
+  Width: 1920
+  X: 1920
+  Y: 0

--- a/src/laserscan_pub.cpp
+++ b/src/laserscan_pub.cpp
@@ -1,0 +1,76 @@
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+#include "tf2_ros/static_transform_broadcaster.h"
+
+using namespace std::chrono_literals;
+
+class LaserScanPublisher : public rclcpp::Node
+{
+public:
+  LaserScanPublisher()
+  : Node("laserscan_pub")
+  {
+    scan_pub = this->create_publisher<sensor_msgs::msg::LaserScan>("scan", 50);
+    timer_ = this->create_wall_timer(1s, std::bind(&LaserScanPublisher::publish_scan, this));
+    // 静的な変換を送信するタイマー
+    static_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
+    send_static_transform();
+  }
+
+private:
+  void publish_scan()
+  {
+    auto scan = sensor_msgs::msg::LaserScan();
+    scan.header.stamp = this->get_clock()->now();
+    scan.header.frame_id = "laser_frame";
+    scan.angle_min = -1.57;
+    scan.angle_max = 1.57;
+    scan.angle_increment = 3.14 / num_readings;
+    scan.time_increment = (1 / laser_frequency) / num_readings;
+    scan.range_min = 0.0;
+    scan.range_max = 100.0;
+
+    scan.ranges.resize(num_readings);
+    scan.intensities.resize(num_readings);
+
+    // 範囲と強度に一定の値を設定
+    for (unsigned int i = 0; i < num_readings; ++i) {
+      scan.ranges[i] = 5.0;         // 一定の範囲値 (例: 10メートル)
+      scan.intensities[i] = 100.0;  // 一定の強度値
+    }
+
+    scan_pub->publish(scan);
+  }
+
+  void send_static_transform()
+  {
+    geometry_msgs::msg::TransformStamped static_transform_stamped;
+    static_transform_stamped.header.stamp = this->get_clock()->now();
+    static_transform_stamped.header.frame_id = "base_link";
+    static_transform_stamped.child_frame_id = "laser_frame";
+    static_transform_stamped.transform.translation.x = 0.0;
+    static_transform_stamped.transform.translation.y = 0.0;
+    static_transform_stamped.transform.translation.z = 0.1;  // 仮にz方向に0.1mのオフセット
+    static_transform_stamped.transform.rotation.x = 0.0;
+    static_transform_stamped.transform.rotation.y = 0.0;
+    static_transform_stamped.transform.rotation.z = 0.0;
+    static_transform_stamped.transform.rotation.w = 1.0;
+    static_broadcaster_->sendTransform(static_transform_stamped);
+  }
+
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr scan_pub;
+  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_broadcaster_;
+  unsigned int num_readings = 100;
+  double laser_frequency = 40.0;
+  int count = 0;
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<LaserScanPublisher>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
概要
- 
- sensor_msgs::msg::LaserScanの疑似データ生成
- rviz2上での可視化及びロボット座標系とlaserフレームの座標変換

変更点
- 
- srcにlaserscan_pub.cppを追加
- laserscan_pubに関わるCMakeLists.txt修正
- laserscan_pubに関わるtutorial_publishers.pyを修正

確認内容
- 
- [x] colcon build
- [x] colcon test
- [x] /scanトピックの出力確認