### PR TITLE
feat：add twist_pub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,10 @@ ament_target_dependencies(odometry_pub rclcpp tf2_geometry_msgs nav_msgs geometr
 add_executable(laserscan_pub src/laserscan_pub.cpp)
 ament_target_dependencies(laserscan_pub rclcpp sensor_msgs tf2_ros geometry_msgs)
 
+# twist_pub
+add_executable(twist_pub src/twist_pub.cpp)
+ament_target_dependencies(twist_pub rclcpp geometry_msgs)
+
 # Install Cpp executables
 install(TARGETS
   talker
@@ -43,6 +47,7 @@ install(TARGETS
   float32_pub
   odometry_pub
   laserscan_pub
+  twist_pub
   DESTINATION lib/${PROJECT_NAME})
 
 # Install other files

--- a/launch/tutorial_publishers.py
+++ b/launch/tutorial_publishers.py
@@ -51,6 +51,12 @@ def generate_launch_description():
         output="screen",
     )
 
+    twist_node = Node(
+        package=package_name,
+        executable='twist_pub',
+        output="screen",
+    )
+
     nodes = [
         rviz_node,
         minimal_publisher_node,
@@ -58,6 +64,7 @@ def generate_launch_description():
         float32_node,
         odometry_node,
         laserscan_node,
+        twist_node,
     ]
 
     return LaunchDescription(nodes)

--- a/src/twist_pub.cpp
+++ b/src/twist_pub.cpp
@@ -1,0 +1,46 @@
+#include "geometry_msgs/msg/twist.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+using namespace std::chrono_literals;
+
+class TwistPublisher : public rclcpp::Node
+{
+public:
+  TwistPublisher()
+  : Node("twist_pub")
+  {
+    publisher_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 10);
+    timer_ = this->create_wall_timer(100ms, std::bind(&TwistPublisher::publish_twist, this));
+  }
+
+private:
+  void publish_twist()
+  {
+    auto message = geometry_msgs::msg::Twist();
+    // 線形速度の設定
+    message.linear.x = 1.0;  // 前進速度 1 m/s
+    message.linear.y = 0.0;
+    message.linear.z = 0.0;
+
+    // 角速度の設定
+    message.angular.x = 0.0;
+    message.angular.y = 0.0;
+    message.angular.z = 0.5;  // 左回りの回転速度 0.5 rad/s
+
+    RCLCPP_INFO(
+      this->get_logger(), "Publishing: 'linear.x: '%.2f', angular.z: '%.2f'", message.linear.x,
+      message.angular.z);
+    publisher_->publish(message);
+  }
+
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr publisher_;
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<TwistPublisher>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
概要
- 
- geometry_msgs/msg/Twistの疑似データ生成

変更点
- 
- srcにtwist_pub.cppを追加
- twist_pubに関わるCMakeLists.txt修正
- twist_pubに関わるtutorial_publishers.pyを修正

確認内容
- 
- [x] colcon build
- [x] colcon test
- [x] /cmd_velトピックの出力確認